### PR TITLE
Allow arbitrary value extraction code to specified

### DIFF
--- a/lib/hal_interpretation/dsl.rb
+++ b/lib/hal_interpretation/dsl.rb
@@ -11,12 +11,22 @@ module HalInterpretation
     # document.
     #
     # attr_name - name of attribute on model to extract
+    #
     # opts - hash of named arguments to method
-    #   :from - JSON path from which to get the value for 
-    #     attribute. Default: "/#{attr_name}"
+    #
+    #   :from - JSON path from which to get the value for
+    #     attribute. Default: "/#{attr_name}".
+    #
+    #   :with - Callable that can extract the value when
+    #     passed a HalClient::Representation of the item.
     def extract(attr_name, opts={})
-      from = opts.fetch(:from) { "/#{attr_name}" }
-      extractors << Extractor.new(attr: attr_name, location: from)
+      extractor_opts = {
+        attr: attr_name,
+        location: opts.fetch(:from) { "/#{attr_name}" }
+      }
+      extractor_opts[:extraction_proc] = opts.fetch(:with) if opts.key? :with
+
+      extractors << Extractor.new(extractor_opts)
     end
   end
 end

--- a/lib/hal_interpretation/extractor.rb
+++ b/lib/hal_interpretation/extractor.rb
@@ -5,10 +5,12 @@ module HalInterpretation
     # opts - named args
     #   :attr - name of attribute this object will extact.
     #   :location - JSON path from which to get the value.
-    def initialize(opts) #attr:, location: "/#{attr}")
+    #   :extraction_proc - Callable that can extract the value when
+    #     passed a HalClient::Representation of the item.
+    def initialize(opts)
       @attr = opts.fetch(:attr) { fail ArgumentError, "attr is required" }
       @location = opts.fetch(:location) { "/#{attr}" }
-      @pointer = Hana::Pointer.new(location)
+      @fetcher = opts.fetch(:extraction_proc) { Hana::Pointer.new(location).method(:eval) }
     end
 
     # opts - named args
@@ -19,7 +21,7 @@ module HalInterpretation
     def extract(opts)
       from = opts.fetch(:from) { fail ArgumentError, "from is required" }
       to = opts.fetch(:to) { fail ArgumentError, "to is required" }
-      to.send "#{attr}=", pointer.eval(from)
+      to.send "#{attr}=", fetcher.call(from)
 
       []
     rescue => err
@@ -29,6 +31,6 @@ module HalInterpretation
     attr_reader :attr, :location
 
     protected
-    attr_reader :pointer
+    attr_reader :fetcher
   end
 end

--- a/spec/hal_interpretation/extractor_spec.rb
+++ b/spec/hal_interpretation/extractor_spec.rb
@@ -1,0 +1,42 @@
+require_relative "../spec_helper"
+
+describe HalInterpretation::Extractor do
+  describe "creation" do
+    specify { expect{described_class.new(attr: "first_name", location: "/firstName")}
+      .not_to raise_error }
+    specify { expect{described_class.new(attr: "first_name", with: ->(hal_repr){ "bob" })}
+      .not_to raise_error }
+  end
+
+  context "location based" do
+    subject(:extractor) { described_class.new(attr: "first_name", location: "/firstName") }
+
+    specify { expect{extractor.extract(from: source, to: target)}.not_to raise_error }
+
+    context "after extraction" do
+      before do extractor.extract(from: source, to: target) end
+
+      specify { expect(target.first_name).to eq "Alice" }
+    end
+  end
+
+  context "lambda based" do
+    subject(:extractor) { described_class
+        .new(attr: "parent", location: "/_links/up",
+             extraction_proc: ->(hal_repr) {hal_repr.related_hrefs("up").first}) }
+
+    specify { expect{extractor.extract(from: source, to: target)}.not_to raise_error }
+
+    context "after extraction" do
+      before do extractor.extract(from: source, to: target) end
+
+      specify { expect(target.parent).to eq "http://foo" }
+    end
+  end
+
+  let(:target) { Struct.new(:first_name, :parent).new }
+  let(:source) { HalClient::Representation.new(parsed_json: {
+                                                 "firstName" => "Alice",
+                                                 "_links" => {
+                                                   "up" => { "href" => "http://foo" }}}) }
+end


### PR DESCRIPTION
Adds a `:with` option to the `#extract` method whose value is a proc that performs the extraction.

``` ruby
   extract "parent", from: "/_links/up", with: ->(hal_repr){hal_repr.related_hrefs("up").first}
```
