### PR TITLE
Run interpretation procs in the context of the interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ class UserHalInterpreter
 
   extract :name
   extract :address_line, from: "address/line1"
+  extract :seq, with: ->(_hal_repr) { next_seq_num }
+  extract :birthday, coercion: ->(date_str) { Date.iso8601(date_str) } 
+
+  def initialize
+    @cur_seq_num = 0
+  end
+
+  protected
+
+  def next_seq_num
+    @cur_seq_num += 1
+  end
 end
 ```
 

--- a/lib/hal_interpretation/extractor.rb
+++ b/lib/hal_interpretation/extractor.rb
@@ -24,14 +24,22 @@ module HalInterpretation
 
     # opts - named args
     #   :from - The HalRepresentation from which to extract attribute.
+    #
     #   :to - The model that we are extracting
+    #
+    #   :context - The context(usually a HalInterpreter) in which to
+    #     execute the extraction
     #
     # Returns any problems encountered.
     def extract(opts)
       from = opts.fetch(:from) { fail ArgumentError, "from is required" }
       to = opts.fetch(:to) { fail ArgumentError, "to is required" }
+      context = opts.fetch(:context, self)
 
-      to.send "#{attr}=", value_coercion.call(fetcher.call(from))
+      raw_val = context.instance_exec from, &fetcher
+      val = context.instance_exec raw_val, &value_coercion
+
+      to.public_send "#{attr}=", val
 
       []
     rescue => err

--- a/lib/hal_interpretation/item_interpreter.rb
+++ b/lib/hal_interpretation/item_interpreter.rb
@@ -40,7 +40,7 @@ module HalInterpretation
       new_item = item_class.new do |it|
         e = extractors
         e.each do |an_extractor|
-          @problems += an_extractor.extract(from: repr, to: it)
+          @problems += an_extractor.extract(from: repr, to: it, context: interpreter)
             .map {|msg| "#{json_path_for an_extractor.attr} #{msg}" }
         end
       end

--- a/lib/hal_interpretation/version.rb
+++ b/lib/hal_interpretation/version.rb
@@ -1,3 +1,3 @@
 module HalInterpretation
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end

--- a/spec/hal_interpretation/extractor_spec.rb
+++ b/spec/hal_interpretation/extractor_spec.rb
@@ -37,6 +37,25 @@ describe HalInterpretation::Extractor do
     end
   end
 
+  context "context dependent lambda based" do
+    subject(:extractor) { described_class
+        .new(attr: "seq", location: "/seq", extraction_proc:
+             ->(hal_repr) { self.count_so_far }) }
+
+    specify { expect{
+        extractor.extract(from: source, to: target, context: interpreter)
+      }.not_to raise_error }
+
+
+    context "after extraction" do
+      before do extractor.extract(from: source, to: target, context: interpreter) end
+
+      specify { expect(target.seq).to eq 42 }
+    end
+
+    let(:interpreter) { double(:interpreter, count_so_far: 42) }
+  end
+
   context "coercion" do
     subject(:extractor) { described_class.new(attr: "bday",
                                               coercion: ->(val){ Time.parse(val) } ) }
@@ -46,7 +65,7 @@ describe HalInterpretation::Extractor do
   end
 
 
-  let(:target) { Struct.new(:first_name, :bday, :parent).new }
+  let(:target) { Struct.new(:first_name, :bday, :parent, :seq).new }
   let(:source) { HalClient::Representation.new(parsed_json: {
                                                  "firstName" => "Alice",
                                                  "bday" => "2013-10-10T12:13:14Z",


### PR DESCRIPTION
This allows the use of instance methods on the interpreter object.
