### PR TITLE
Delegate all validity checking to model

### DIFF
--- a/lib/hal_interpretation/extractor.rb
+++ b/lib/hal_interpretation/extractor.rb
@@ -37,6 +37,8 @@ module HalInterpretation
       context = opts.fetch(:context, self)
 
       raw_val = context.instance_exec from, &fetcher
+      return [] unless raw_val
+
       val = context.instance_exec raw_val, &value_coercion
 
       to.public_send "#{attr}=", val

--- a/lib/hal_interpretation/item_interpreter.rb
+++ b/lib/hal_interpretation/item_interpreter.rb
@@ -54,13 +54,23 @@ module HalInterpretation
 
     def apply_validations(an_item)
       an_item.valid?
+
       an_item.errors.each do |attr, msg|
-        @problems << "#{json_path_for attr} #{msg}"
+        leader = begin
+                   json_path_for attr
+                 rescue KeyError
+                   "#{attr} [which is not directly extracted from JSON]"
+                 end
+
+        @problems << leader + " " + msg
       end
     end
 
     def json_path_for(attr)
-      json_pointer_join(location, extractor_for(attr).location)
+      extractor = extractor_for(attr)
+      raise KeyError unless extractor
+
+      json_pointer_join(location, extractor.location)
     end
 
     def json_pointer_join(head, tail)

--- a/lib/hal_interpretation/version.rb
+++ b/lib/hal_interpretation/version.rb
@@ -1,3 +1,3 @@
 module HalInterpretation
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/spec/hal_interpretation/extractor_spec.rb
+++ b/spec/hal_interpretation/extractor_spec.rb
@@ -64,9 +64,26 @@ describe HalInterpretation::Extractor do
     specify { expect(target.bday).to eq Time.utc(2013,10,10,12,13,14) }
   end
 
+  context "basic attr" do
+    subject(:extractor) { described_class.new(attr: "age") }
 
-  let(:target) { Struct.new(:first_name, :bday, :parent, :seq).new }
+    before do extractor.extract(from: source, to: target) end
+
+    specify { expect(target.age).to eq 1 }
+  end
+
+  context "missing attr" do
+    subject(:extractor) { described_class.new(attr: "seq") }
+
+    before do extractor.extract(from: source, to: target) end
+
+    specify { expect(target.seq).to be_nil }
+  end
+
+
+  let(:target) { Struct.new(:first_name, :bday, :parent, :seq, :age).new }
   let(:source) { HalClient::Representation.new(parsed_json: {
+                                                 "age" => 1,
                                                  "firstName" => "Alice",
                                                  "bday" => "2013-10-10T12:13:14Z",
                                                  "_links" => {


### PR DESCRIPTION
Also don't blow up when there are errors on attributes that are not
directly mapped from the json
