### PR TITLE
add `#collection?` predicate to interpeters

### DIFF
--- a/lib/hal_interpretation.rb
+++ b/lib/hal_interpretation.rb
@@ -41,6 +41,12 @@ module HalInterpretation
     @problems ||= interpreters.flat_map(&:problems)
   end
 
+  # returns true if the json interpreted was a collection (had
+  # embedded items) even if there was only one; otherwise false
+  def collection?
+    repr.has_related?("item")
+  end
+
   extend Forwardable
   def_delegators "self.class", :extractors, :extractor_for
 

--- a/lib/hal_interpretation/version.rb
+++ b/lib/hal_interpretation/version.rb
@@ -1,3 +1,3 @@
 module HalInterpretation
-  VERSION = "1.5.0"
+  VERSION = "1.6.0"
 end

--- a/spec/hal_interpretation_spec.rb
+++ b/spec/hal_interpretation_spec.rb
@@ -59,6 +59,8 @@ describe HalInterpretation do
 
     specify { expect(interpreter.problems).to be_empty }
 
+    specify { expect(interpreter.collection?).to be false }
+
     context "for update" do
       let(:existing) { test_item_class.new do |it|
                          it.name = "foo"
@@ -127,6 +129,8 @@ describe HalInterpretation do
 
     specify { expect{interpreter.item}
               .to raise_error HalInterpretation::InvalidRepresentationError }
+
+    specify { expect(interpreter.collection?).to be true }
 
     matcher :item_named do |expected_name|
       match do |obj|


### PR DESCRIPTION
Allows controllers to more easily produce responses that match the in bound doc.