### PR TITLE
Adding `extract_repr` and `extract_reprs` to HalInterpretation DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ class UserHalInterpreter
   # Extract the target of the rel link and assign a HAL representation to the person
   # attribute of the model. Reports a problem if more than one link of this
   # type is present.
-  extract_repr  :profile, rel: "http://xmlns.com/foaf/0.1/Person",
+  extract_related  :profile, rel: "http://xmlns.com/foaf/0.1/Person",
     coercion: ->(profile_repr) { CustomInterpretation.new(profile_repr) }
 
   # Extract the target of the rel link and assign a HAL representation
   # set to the cohorts attribute of the model. Reports a problem if
   # more than one link of this type is present.
-  extract_reprs  :cohorts, rel: "http://xmlns.com/foaf/0.1/knows",
+  extract_relateds  :cohorts, rel: "http://xmlns.com/foaf/0.1/knows",
     coercion: ->(cohort_repr_set) {
       cohort_repr_set.map {|repr| CustomInterpretation.new(repr) }
     }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ class UserHalInterpreter
   # type is present.
   extract_link  :up
 
+  # Extract the target of the rel link and assign a HAL representation to the person
+  # attribute of the model. Reports a problem if more than one link of this
+  # type is present.
+  extract_repr  :profile, rel: "http://xmlns.com/foaf/0.1/Person",
+    coercion: ->(profile_repr) { CustomInterpretation.new(profile_repr) }
+
+  # Extract the target of the rel link and assign a HAL representation
+  # set to the cohorts attribute of the model. Reports a problem if
+  # more than one link of this type is present.
+  extract_reprs  :cohorts, rel: "http://xmlns.com/foaf/0.1/knows",
+    coercion: ->(cohort_repr_set) {
+      cohort_repr_set.map {|repr| CustomInterpretation.new(repr) }
+    }
 
   def initialize
     @cur_seq_num = 0
@@ -65,6 +78,7 @@ This interpreter will work for documents that look like the following
   },
   "birthday": "1980-08-31",
   "_links": {
+    "http://xmlns.com/foaf/0.1/Person": { "href": "http://example.com/bob" },
     "http://xmlns.com/foaf/0.1/knows": [
       { "href": "http://example.com/alice" },
       { "href": "http://example.com/mallory" }
@@ -85,6 +99,7 @@ or
         },
         "birthday": "1980-08-31",
         "_links": {
+          "http://xmlns.com/foaf/0.1/Person": { "href": "http://example.com/bob" },
           "http://xmlns.com/foaf/0.1/knows": [
             { "href": "http://example.com/alice" },
             { "href": "http://example.com/mallory" }
@@ -99,6 +114,7 @@ or
         },
         "birthday": "1979-02-16",
         "_links": {
+          "http://xmlns.com/foaf/0.1/Person": { "href": "http://example.com/alice },
           "http://xmlns.com/foaf/0.1/knows": [
             { "href": "http://example.com/bob" },
             { "href": "http://example.com/mallory" }

--- a/lib/hal_interpretation/dsl.rb
+++ b/lib/hal_interpretation/dsl.rb
@@ -149,8 +149,8 @@ module HalInterpretation
     # looks up the author pointed to by the rel and uses coercion to
     # initialize a custom object stored on the model that uses the
     # representation
-    def extract_repr(attr_name, opts={})
-      extract_reprs_with_blk(attr_name, opts) {|r, rel| r.related(rel){[]}.first }
+    def extract_related(attr_name, opts={})
+      extract_related_with_blk(attr_name, opts) {|r, rel| r.related(rel){[]}.first }
     end
 
     # Declare that an attribute should be extracted from the HAL
@@ -183,14 +183,14 @@ module HalInterpretation
     # looks up the authors pointed to by the rel and uses coercion to
     # initialize an array of custom objects stored on the model that
     # uses the representation set
-    def extract_reprs(attr_name, opts={})
-      extract_reprs_with_blk(attr_name, opts) {|r, rel| r.related(rel){[]} }
+    def extract_relateds(attr_name, opts={})
+      extract_related_with_blk(attr_name, opts) {|r, rel| r.related(rel){[]} }
     end
 
 
     protected
 
-    def extract_reprs_with_blk(attr_name, opts={}, &blk)
+    def extract_related_with_blk(attr_name, opts={}, &blk)
       rel = opts.fetch(:rel) { attr_name }.to_s
       path = "/_links/" + json_path_escape(rel)
 

--- a/lib/hal_interpretation/version.rb
+++ b/lib/hal_interpretation/version.rb
@@ -1,3 +1,3 @@
 module HalInterpretation
-  VERSION = "1.7.0"
+  VERSION = "1.8.0"
 end

--- a/spec/hal_interpretation_spec.rb
+++ b/spec/hal_interpretation_spec.rb
@@ -18,8 +18,8 @@ describe HalInterpretation do
       extract_links :friend_ids, rel: "http://xmlns.com/foaf/0.1/knows",
                     coercion: ->(urls) { urls.map{|u| u.split("/").last } }
       extract_link :archives_url_tmpl, rel: "archives"
-      extract_repr :profile, rel: "http://xmlns.com/foaf/0.1/Person"
-      extract_reprs :cohorts, rel: "http://xmlns.com/foaf/0.1/knows"
+      extract_related :profile, rel: "http://xmlns.com/foaf/0.1/Person"
+      extract_relateds :cohorts, rel: "http://xmlns.com/foaf/0.1/knows"
 
       def initialize(*args)
         @cur_seq_num = 0


### PR DESCRIPTION
  These methods will allow the DSL user to work with a
  HalClient::Representation or HalClient::RepresentationSet for use on
  the model's associated property or for any coercion work that needs
  to be done. Please see README and method documentation for more
  details on usage and implementation.