### PR TITLE
Fixes assumption of executing block on initialization of a model

### DIFF
--- a/lib/hal_interpretation.rb
+++ b/lib/hal_interpretation.rb
@@ -57,7 +57,7 @@ module HalInterpretation
       yield item_to_update
       item_to_update
     else
-      item_class.new(&blk)
+      item_class.new.tap(&blk)
     end
   end
 

--- a/lib/hal_interpretation/version.rb
+++ b/lib/hal_interpretation/version.rb
@@ -1,3 +1,3 @@
 module HalInterpretation
-  VERSION = "1.8.0"
+  VERSION = "1.8.1"
 end

--- a/spec/hal_interpretation_spec.rb
+++ b/spec/hal_interpretation_spec.rb
@@ -299,10 +299,6 @@ describe HalInterpretation do
       attr_accessor :name, :latitude, :up, :bday, :seq, :hair, :friend_ids,
                     :archives_url_tmpl, :profile, :cohorts
 
-      def initialize
-        yield self
-      end
-
       def latitude=(lat)
         @latitude = if !lat.nil?
                       Float(lat)


### PR DESCRIPTION
  This was causing ActiveModel classes to not get hydrated.

  ActiveRecord automatically handles executing blocks on
  initialization of its models, but ActiveModel does not.

  Instead, we explicitly call the block on initialization to not rely
  on ActiveModel or ActiveRecord to do it for us.