### PR TITLE
Allows custom option parsing on initialization of HalInterpretation 

### DIFF
--- a/lib/hal_interpretation.rb
+++ b/lib/hal_interpretation.rb
@@ -66,9 +66,16 @@ module HalInterpretation
   # opts
   #   :location - The json path of `a_representation` in the
   #     complete document
+  #
+  # optionally implement `#handle_initialization_opts` for custom option parsing
   def initialize(a_representation, opts)
     @repr = a_representation
     @location = opts.fetch(:location) { raise ArgumentError, "location is required" }
+    handle_initialization_opts(opts)
+  end
+
+  # allows custom setting of options on initialization
+  def handle_initialization_opts(opts)
   end
 
   attr_reader :repr, :location
@@ -104,9 +111,9 @@ module HalInterpretation
     #
     # Raises HalInterpretation::InvalidRepresentationError if the
     #   provided JSON document is not parseable
-    def new_from_json(json)
-      self.new HalClient::Representation.new(parsed_json: MultiJson.load(json)),
-               location: "/"
+    def new_from_json(json, opts = {})
+      repr = HalClient::Representation.new(parsed_json: MultiJson.load(json))
+      self.new repr, opts.merge(location: "/")
 
     rescue MultiJson::ParseError => err
       fail InvalidRepresentationError, "Parse error: " + err.message

--- a/lib/hal_interpretation/dsl.rb
+++ b/lib/hal_interpretation/dsl.rb
@@ -134,14 +134,14 @@ module HalInterpretation
     #
     # Examples
     #
-    #     extract_repr :author,
+    #     extract_related :author,
     #                   rel: "http://xmlns.com/foaf/0.1/Person"
     #
     # extracts the targets of the `.../Person` link and stores the
     # corresponding HAL representation object in the `author`
     # attribute of the model.
     #
-    #     extract_repr :author, rel: "http://xmlns.com/foaf/0.1/Person",
+    #     extract_related :author, rel: "http://xmlns.com/foaf/0.1/Person",
     #                   coercion: ->(person_repr) {
     #                     MyInterpretation.new(person_repr)
     #                   }
@@ -168,14 +168,14 @@ module HalInterpretation
     #
     # Examples
     #
-    #     extract_reprs :authors,
+    #     extract_relateds :authors,
     #                    rel: "http://exampe.com/authors"
     #
     # extracts the targets of the `.../authors` link and stores the
     # corresponding HAL representation set object in the `authors`
     # attribute of the model.
     #
-    #     extract_reprs :authors, rel: "http://example.com/authors",
+    #     extract_relateds :authors, rel: "http://example.com/authors",
     #       coercion: ->(person_repr_set) {
     #         person_repr_set.map {|repr| MyInterpretation.new(repr)}
     #       }

--- a/lib/hal_interpretation/version.rb
+++ b/lib/hal_interpretation/version.rb
@@ -1,3 +1,3 @@
 module HalInterpretation
-  VERSION = "1.8.1"
+  VERSION = "1.9.0"
 end


### PR DESCRIPTION
This was needed in order to set conditional flags when interpreting CGJ bodies.